### PR TITLE
Modify encoding related issues

### DIFF
--- a/lib/src/bindings/blob.dart
+++ b/lib/src/bindings/blob.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-
 import 'package:ffi/ffi.dart';
 import 'package:git2dart/src/extensions.dart';
 import 'package:git2dart/src/helpers/error_helper.dart';
@@ -38,8 +37,8 @@ bool isBinary(Pointer<git_blob> blob) {
 /// Get a read-only buffer with the raw content of a blob.
 ///
 /// Returns the raw content as a UTF-8 string.
-String content(Pointer<git_blob> blob) {
-  return libgit2.git_blob_rawcontent(blob).cast<Utf8>().toDartString();
+Pointer<Utf8> content(Pointer<git_blob> blob) {
+  return libgit2.git_blob_rawcontent(blob).cast<Utf8>();
 }
 
 /// Get the size in bytes of the contents of a blob.

--- a/lib/src/blob.dart
+++ b/lib/src/blob.dart
@@ -1,6 +1,6 @@
 import 'dart:ffi';
-
 import 'package:equatable/equatable.dart';
+import 'package:ffi/ffi.dart';
 import 'package:git2dart/git2dart.dart';
 import 'package:git2dart/src/bindings/blob.dart' as bindings;
 import 'package:git2dart_binaries/git2dart_binaries.dart';
@@ -82,7 +82,7 @@ class Blob extends Equatable {
   bool get isBinary => bindings.isBinary(_blobPointer);
 
   /// Read-only buffer with the raw content of a blob.
-  String get content => bindings.content(_blobPointer);
+  Pointer<Utf8> get contentBytes => bindings.content(_blobPointer);
 
   /// Size in bytes of the contents of a blob.
   int get size => bindings.size(_blobPointer);


### PR DESCRIPTION
patch.dart modification
Modify the encoding method to prevent errors caused by non-UTF8 encoding
Adding the contentbytes field will return the original data for users to customize the encoding type

blob.dart Change
Remove the call to the toDartString() method and modify the return type, as calling the toDartString() method on binary data will result in errors and binary data should not return a String type