### PR TITLE
Add stream helpers to Blob API

### DIFF
--- a/lib/git2dart.dart
+++ b/lib/git2dart.dart
@@ -39,3 +39,4 @@ export 'src/tag.dart';
 export 'src/tree.dart';
 export 'src/treebuilder.dart';
 export 'src/worktree.dart';
+export 'src/writestream.dart';

--- a/lib/src/bindings/blob.dart
+++ b/lib/src/bindings/blob.dart
@@ -200,8 +200,13 @@ Pointer<git_oid> createFromStreamCommit(Pointer<git_writestream> stream) {
 }
 
 /// Determine if the given content is most certainly binary or not.
-bool dataIsBinary({required Pointer<Char> data, required int len}) {
-  return libgit2.git_blob_data_is_binary(data, len) == 1;
+bool dataIsBinary({required Uint8List data, required int len}) {
+ return using((arena) {
+      final buffer = arena<Uint8>(data.length);
+      buffer.asTypedList(data.length).setAll(0, data);
+      
+      return libgit2.git_blob_data_is_binary(buffer.cast<Char>(), len) == 1;
+    });
 }
 
 /// Get a buffer with the filtered content of a blob.

--- a/lib/src/blob.dart
+++ b/lib/src/blob.dart
@@ -2,7 +2,6 @@ import 'dart:ffi';
 import 'dart:typed_data';
 
 import 'package:equatable/equatable.dart';
-import 'package:ffi/ffi.dart';
 import 'package:git2dart/git2dart.dart';
 import 'package:git2dart/src/bindings/blob.dart' as bindings;
 import 'package:git2dart_binaries/git2dart_binaries.dart';
@@ -97,11 +96,7 @@ class Blob extends Equatable {
 
   /// Determine if the given content is most certainly binary or not.
   static bool dataIsBinary(Uint8List data) {
-    return using((arena) {
-      final buffer = arena<Uint8>(data.length);
-      buffer.asTypedList(data.length).setAll(0, data);
-      return bindings.dataIsBinary(data: buffer.cast<Char>(), len: data.length);
-    });
+      return bindings.dataIsBinary(data: data, len: data.length);
   }
 
   /// [Oid] of the blob.

--- a/lib/src/blob.dart
+++ b/lib/src/blob.dart
@@ -91,7 +91,9 @@ class Blob extends Equatable {
   ///
   /// Throws a [LibGit2Error] if error occured.
   static Oid createFromStreamCommit(BlobWriteStream stream) {
-    return Oid(bindings.createFromStreamCommit(stream.pointer));
+    final oid = Oid(bindings.createFromStreamCommit(stream.pointer));
+    stream.detach();
+    return oid;
   }
 
   /// Determine if the given content is most certainly binary or not.

--- a/lib/src/writestream.dart
+++ b/lib/src/writestream.dart
@@ -1,0 +1,43 @@
+import 'dart:ffi';
+import 'dart:typed_data';
+
+import 'package:ffi/ffi.dart';
+import 'package:git2dart/src/helpers/error_helper.dart';
+import 'package:git2dart_binaries/git2dart_binaries.dart';
+import 'package:meta/meta.dart';
+
+/// Wrapper around libgit2 `git_writestream` used for streamed blob creation.
+@immutable
+class BlobWriteStream {
+  /// Initialize a new instance from the underlying pointer.
+  @internal
+  const BlobWriteStream(this._pointer);
+
+  final Pointer<git_writestream> _pointer;
+
+  /// Pointer to the underlying `git_writestream` structure.
+  @internal
+  Pointer<git_writestream> get pointer => _pointer;
+
+  /// Write raw [data] into the stream.
+  ///
+  /// Throws a [LibGit2Error] if an error occurs.
+  void write(Uint8List data) {
+    final writeFn =
+        _pointer.ref.write
+            .asFunction<
+              int Function(Pointer<git_writestream>, Pointer<Char>, int)
+            >();
+    using((arena) {
+      final buf = arena<Uint8>(data.length);
+      buf.asTypedList(data.length).setAll(0, data);
+      final error = writeFn(_pointer, buf.cast<Char>(), data.length);
+      checkErrorAndThrow(error);
+    });
+  }
+
+  /// Write UTF-8 [text] into the stream.
+  void writeString(String text) {
+    write(Uint8List.fromList(text.codeUnits));
+  }
+}

--- a/test/blob_test.dart
+++ b/test/blob_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:git2dart/git2dart.dart';
 import 'package:git2dart_binaries/git2dart_binaries.dart';
@@ -159,6 +160,24 @@ void main() {
       expect(blob.size, bytes.length);
       expect(blob.content, 'hi');
       expect(blob.contentBytes, bytes);
+    });
+
+    test('creates blob from stream', () {
+      final stream = Blob.createFromStream(repo: repo);
+
+      stream.writeString(newBlobContent);
+      final oid = Blob.createFromStreamCommit(stream);
+      final blob = Blob.lookup(repo: repo, oid: oid);
+
+      expect(blob.content, newBlobContent);
+    });
+
+    test('detects binary data', () {
+      final binary = Uint8List.fromList([0x00, 0xff]);
+      final text = Uint8List.fromList([0x61, 0x62, 0x63]);
+
+      expect(Blob.dataIsBinary(binary), isTrue);
+      expect(Blob.dataIsBinary(text), isFalse);
     });
 
     test('manually releases allocated memory', () {


### PR DESCRIPTION
## Summary
- expose blob creation from streams and binary detection utilities
- add BlobWriteStream wrapper and update tests

## Testing
- `dart analyze`
- `dart test` *(fails: git_error_t.GIT_ERROR_OS: failed to connect to github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68483c9947e0832d87e0ed5903950312