### PR TITLE
Expose new worktree helpers

### DIFF
--- a/lib/src/worktree.dart
+++ b/lib/src/worktree.dart
@@ -47,6 +47,14 @@ class Worktree extends Equatable {
     _finalizer.attach(this, _worktreePointer, detach: this);
   }
 
+  /// Opens the main worktree belonging to the provided [repo].
+  ///
+  /// Throws a [LibGit2Error] if an error occurs.
+  Worktree.openFromRepository({required Repository repo}) {
+    _worktreePointer = bindings.openFromRepository(repo.pointer);
+    _finalizer.attach(this, _worktreePointer, detach: this);
+  }
+
   /// Pointer to the memory address for the allocated worktree object.
   late final Pointer<git_worktree> _worktreePointer;
 
@@ -100,6 +108,19 @@ class Worktree extends Equatable {
       flags: flags?.fold(0, (acc, e) => acc! | e.value),
     );
   }
+
+  /// Opens the repository that belongs to this worktree.
+  ///
+  /// Throws a [LibGit2Error] if an error occurs.
+  Repository repositoryFromWorktree() {
+    final pointer = bindings.repositoryFromWorktree(_worktreePointer);
+    return Repository(pointer);
+  }
+
+  /// Validates the worktree configuration.
+  ///
+  /// Throws a [LibGit2Error] if the worktree is invalid.
+  void validate() => bindings.validate(_worktreePointer);
 
   /// Checks if the worktree is valid.
   ///

--- a/test/worktree_test.dart
+++ b/test/worktree_test.dart
@@ -187,8 +187,10 @@ void main() {
       final repoWt = Repository.open(worktreeDir.path);
       final worktree = Worktree.openFromRepository(repo: repoWt);
 
+      final resolved = Directory(worktreeDir.path).resolveSymbolicLinksSync();
+
       expect(worktree.name, worktreeName);
-      expect(worktree.path, worktreeDir.path);
+      expect(worktree.path, resolved);
       expect(worktree.isValid, true);
     });
 

--- a/test/worktree_test.dart
+++ b/test/worktree_test.dart
@@ -190,7 +190,7 @@ void main() {
       final resolved = Directory(worktreeDir.path).resolveSymbolicLinksSync();
 
       expect(worktree.name, worktreeName);
-      expect(worktree.path, resolved);
+      expect(p.normalize(worktree.path), p.normalize(resolved));
       expect(worktree.isValid, true);
     });
 
@@ -204,8 +204,8 @@ void main() {
       final repoFromWt = worktree.repositoryFromWorktree();
 
       expect(
-        repoFromWt.path,
-        contains(p.join('.git', 'worktrees', worktreeName)),
+        p.normalize(repoFromWt.path),
+        contains(p.normalize(p.join('.git', 'worktrees', worktreeName))),
       );
     });
 

--- a/test/worktree_test.dart
+++ b/test/worktree_test.dart
@@ -180,5 +180,45 @@ void main() {
       );
       expect(worktree, equals(Worktree.lookup(repo: repo, name: worktreeName)));
     });
+
+    test('opens worktree from repository', () {
+      Worktree.create(repo: repo, name: worktreeName, path: worktreeDir.path);
+
+      final repoWt = Repository.open(worktreeDir.path);
+      final worktree = Worktree.openFromRepository(repo: repoWt);
+
+      expect(worktree.name, worktreeName);
+      expect(worktree.path, worktreeDir.path);
+      expect(worktree.isValid, true);
+    });
+
+    test('returns repository from worktree', () {
+      final worktree = Worktree.create(
+        repo: repo,
+        name: worktreeName,
+        path: worktreeDir.path,
+      );
+
+      final repoFromWt = worktree.repositoryFromWorktree();
+
+      expect(
+        repoFromWt.path,
+        contains(p.join('.git', 'worktrees', worktreeName)),
+      );
+    });
+
+    test('validates worktree configuration', () {
+      final worktree = Worktree.create(
+        repo: repo,
+        name: worktreeName,
+        path: worktreeDir.path,
+      );
+
+      expect(() => worktree.validate(), returnsNormally);
+
+      worktreeDir.deleteSync(recursive: true);
+
+      expect(() => worktree.validate(), throwsA(isA<LibGit2Error>()));
+    });
   });
 }


### PR DESCRIPTION
## Summary
- expose new helper functions for worktrees
- cover new functionality with tests

## Testing
- `dart test test/worktree_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_684863d7c1cc832dad0bfdb5608e1c5d