### PR TITLE
Add basic Git2DartError tests

### DIFF
--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -1,0 +1,15 @@
+import 'package:git2dart/git2dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Git2DartError', () {
+    test('toString returns message', () {
+      expect(Git2DartError('msg').toString(), 'msg');
+    });
+
+    test('stackTrace is not null', () {
+      final error = Git2DartError('msg');
+      expect(error.stackTrace, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add new `error_test.dart` verifying `Git2DartError`

## Testing
- `flutter test --exclude-tags remote_fetch`

------
https://chatgpt.com/codex/tasks/task_e_68487f274348832d95a8c94aaabe8e44