### PR TITLE
Add fromValue tests for enums

### DIFF
--- a/test/git_types_bindings_test.dart
+++ b/test/git_types_bindings_test.dart
@@ -1,0 +1,137 @@
+import 'package:git2dart/git2dart.dart';
+import 'package:git2dart_binaries/git2dart_binaries.dart';
+import 'package:test/test.dart';
+
+void compareEnums(List dartValues, List ffiValues) {
+  final dartSet = {for (var e in dartValues) (e as dynamic).value as int};
+  final ffiSet = {for (var e in ffiValues) (e as dynamic).value as int};
+  expect(dartSet, ffiSet);
+}
+
+void main() {
+  group('enum values match bindings', () {
+    test('ReferenceType', () {
+      compareEnums(ReferenceType.values, git_reference_t.values);
+    });
+    test('GitFilemode', () {
+      compareEnums(GitFilemode.values, git_filemode_t.values);
+    });
+    test('GitSort', () {
+      compareEnums(GitSort.values, git_sort_t.values);
+    });
+    test('GitObject', () {
+      compareEnums(GitObject.values, git_object_t.values);
+    });
+    test('GitRevSpec', () {
+      compareEnums(GitRevSpec.values, git_revspec_t.values);
+    });
+    test('GitBranch', () {
+      compareEnums(GitBranch.values, git_branch_t.values);
+    });
+    test('GitStatus', () {
+      compareEnums(GitStatus.values, git_status_t.values);
+    });
+    test('GitMergeAnalysis', () {
+      compareEnums(GitMergeAnalysis.values, git_merge_analysis_t.values);
+    });
+    test('GitMergePreference', () {
+      compareEnums(GitMergePreference.values, git_merge_preference_t.values);
+    });
+    test('GitRepositoryState', () {
+      compareEnums(GitRepositoryState.values, git_repository_state_t.values);
+    });
+    test('GitMergeFlag', () {
+      compareEnums(GitMergeFlag.values, git_merge_flag_t.values);
+    });
+    test('GitMergeFileFavor', () {
+      compareEnums(GitMergeFileFavor.values, git_merge_file_favor_t.values);
+    });
+    test('GitMergeFileFlag', () {
+      compareEnums(GitMergeFileFlag.values, git_merge_file_flag_t.values);
+    });
+    test('GitCheckout', () {
+      compareEnums(GitCheckout.values, git_checkout_strategy_t.values);
+    });
+    test('GitReset', () {
+      compareEnums(GitReset.values, git_reset_t.values);
+    });
+    test('GitDiff', () {
+      compareEnums(GitDiff.values, git_diff_option_t.values);
+    });
+    test('GitDelta', () {
+      compareEnums(GitDelta.values, git_delta_t.values);
+    });
+    test('GitDiffFlag', () {
+      compareEnums(GitDiffFlag.values, git_diff_flag_t.values);
+    });
+    test('GitDiffStats', () {
+      compareEnums(GitDiffStats.values, git_diff_stats_format_t.values);
+    });
+    test('GitDiffFind', () {
+      compareEnums(GitDiffFind.values, git_diff_find_t.values);
+    });
+    test('GitDiffLine', () {
+      compareEnums(GitDiffLine.values, git_diff_line_t.values);
+    });
+    test('GitApplyLocation', () {
+      compareEnums(GitApplyLocation.values, git_apply_location_t.values);
+    });
+    test('GitConfigLevel', () {
+      compareEnums(GitConfigLevel.values, git_config_level_t.values);
+    });
+    test('GitStash', () {
+      compareEnums(GitStash.values, git_stash_flags.values);
+    });
+    test('GitStashApply', () {
+      compareEnums(GitStashApply.values, git_stash_apply_flags.values);
+    });
+    test('GitDirection', () {
+      compareEnums(GitDirection.values, git_direction.values);
+    });
+    test('GitFetchPrune', () {
+      compareEnums(GitFetchPrune.values, git_fetch_prune_t.values);
+    });
+    test('GitRepositoryInit', () {
+      compareEnums(GitRepositoryInit.values, git_repository_init_flag_t.values);
+    });
+    test('GitCredential', () {
+      compareEnums(GitCredential.values, git_credential_t.values);
+    });
+    test('GitFeature', () {
+      compareEnums(GitFeature.values, git_feature_t.values);
+    });
+    test('GitAttributeCheck', () {
+      compareEnums(GitAttributeCheck.values, git_attr_value_t.values);
+    });
+    test('GitBlameFlag', () {
+      compareEnums(GitBlameFlag.values, git_blame_flag_t.values);
+    });
+    test('GitRebaseOperation', () {
+      compareEnums(GitRebaseOperation.values, git_rebase_operation_t.values);
+    });
+    test('GitDescribeStrategy', () {
+      compareEnums(GitDescribeStrategy.values, git_describe_strategy_t.values);
+    });
+    test('GitSubmoduleIgnore', () {
+      compareEnums(GitSubmoduleIgnore.values, git_submodule_ignore_t.values);
+    });
+    test('GitSubmoduleUpdate', () {
+      compareEnums(GitSubmoduleUpdate.values, git_submodule_update_t.values);
+    });
+    test('GitSubmoduleStatus', () {
+      compareEnums(GitSubmoduleStatus.values, git_submodule_status_t.values);
+    });
+    test('GitIndexCapability', () {
+      compareEnums(GitIndexCapability.values, git_index_capability_t.values);
+    });
+    test('GitBlobFilter', () {
+      compareEnums(GitBlobFilter.values, git_blob_filter_flag_t.values);
+    });
+    test('GitIndexAddOption', () {
+      compareEnums(GitIndexAddOption.values, git_index_add_option_t.values);
+    });
+    test('GitWorktree', () {
+      compareEnums(GitWorktree.values, git_worktree_prune_t.values);
+    });
+  });
+}

--- a/test/git_types_test.dart
+++ b/test/git_types_test.dart
@@ -565,4 +565,122 @@ void main() {
     final actual = {for (final e in GitWorktree.values) e: e.value};
     expect(actual, expected);
   });
+
+  group('fromValue', () {
+    void testEnum<T>(String name, T Function(int) fromValue, List<T> values) {
+      group(name, () {
+        test('returns enum', () {
+          for (final v in values) {
+            expect(fromValue((v as dynamic).value as int), v);
+          }
+        });
+
+        test('throws ArgumentError for invalid value', () {
+          final invalid =
+              values
+                  .map((e) => (e as dynamic).value as int)
+                  .reduce((a, b) => a > b ? a : b) +
+              1;
+          expect(() => fromValue(invalid), throwsArgumentError);
+        });
+      });
+    }
+
+    testEnum('ReferenceType', ReferenceType.fromValue, ReferenceType.values);
+    testEnum('GitFilemode', GitFilemode.fromValue, GitFilemode.values);
+    testEnum('GitSort', GitSort.fromValue, GitSort.values);
+    testEnum('GitObject', GitObject.fromValue, GitObject.values);
+    testEnum('GitRevSpec', GitRevSpec.fromValue, GitRevSpec.values);
+    testEnum('GitBranch', GitBranch.fromValue, GitBranch.values);
+    testEnum('GitStatus', GitStatus.fromValue, GitStatus.values);
+    testEnum(
+      'GitMergeAnalysis',
+      GitMergeAnalysis.fromValue,
+      GitMergeAnalysis.values,
+    );
+    testEnum(
+      'GitMergePreference',
+      GitMergePreference.fromValue,
+      GitMergePreference.values,
+    );
+    testEnum(
+      'GitRepositoryState',
+      GitRepositoryState.fromValue,
+      GitRepositoryState.values,
+    );
+    testEnum('GitMergeFlag', GitMergeFlag.fromValue, GitMergeFlag.values);
+    testEnum(
+      'GitMergeFileFavor',
+      GitMergeFileFavor.fromValue,
+      GitMergeFileFavor.values,
+    );
+    testEnum(
+      'GitMergeFileFlag',
+      GitMergeFileFlag.fromValue,
+      GitMergeFileFlag.values,
+    );
+    testEnum('GitCheckout', GitCheckout.fromValue, GitCheckout.values);
+    testEnum('GitReset', GitReset.fromValue, GitReset.values);
+    testEnum('GitDiff', GitDiff.fromValue, GitDiff.values);
+    testEnum('GitDelta', GitDelta.fromValue, GitDelta.values);
+    testEnum('GitDiffFlag', GitDiffFlag.fromValue, GitDiffFlag.values);
+    testEnum('GitDiffStats', GitDiffStats.fromValue, GitDiffStats.values);
+    testEnum('GitDiffFind', GitDiffFind.fromValue, GitDiffFind.values);
+    testEnum('GitDiffLine', GitDiffLine.fromValue, GitDiffLine.values);
+    testEnum('GitConfigLevel', GitConfigLevel.fromValue, GitConfigLevel.values);
+    testEnum('GitStash', GitStash.fromValue, GitStash.values);
+    testEnum('GitStashApply', GitStashApply.fromValue, GitStashApply.values);
+    testEnum('GitDirection', GitDirection.fromValue, GitDirection.values);
+    testEnum('GitFetchPrune', GitFetchPrune.fromValue, GitFetchPrune.values);
+    testEnum(
+      'GitRepositoryInit',
+      GitRepositoryInit.fromValue,
+      GitRepositoryInit.values,
+    );
+    testEnum('GitCredential', GitCredential.fromValue, GitCredential.values);
+    testEnum('GitFeature', GitFeature.fromValue, GitFeature.values);
+    testEnum(
+      'GitAttributeCheck',
+      GitAttributeCheck.fromValue,
+      GitAttributeCheck.values,
+    );
+    testEnum('GitBlameFlag', GitBlameFlag.fromValue, GitBlameFlag.values);
+    testEnum(
+      'GitRebaseOperation',
+      GitRebaseOperation.fromValue,
+      GitRebaseOperation.values,
+    );
+    testEnum(
+      'GitDescribeStrategy',
+      GitDescribeStrategy.fromValue,
+      GitDescribeStrategy.values,
+    );
+    testEnum(
+      'GitSubmoduleIgnore',
+      GitSubmoduleIgnore.fromValue,
+      GitSubmoduleIgnore.values,
+    );
+    testEnum(
+      'GitSubmoduleUpdate',
+      GitSubmoduleUpdate.fromValue,
+      GitSubmoduleUpdate.values,
+    );
+    testEnum(
+      'GitSubmoduleStatus',
+      GitSubmoduleStatus.fromValue,
+      GitSubmoduleStatus.values,
+    );
+    testEnum(
+      'GitIndexCapability',
+      GitIndexCapability.fromValue,
+      GitIndexCapability.values,
+    );
+    testEnum('GitBlobFilter', GitBlobFilter.fromValue, GitBlobFilter.values);
+    testEnum(
+      'GitIndexAddOption',
+      GitIndexAddOption.fromValue,
+      GitIndexAddOption.values,
+    );
+    testEnum('GitWorktree', GitWorktree.fromValue, GitWorktree.values);
+  });
 }


### PR DESCRIPTION
## Summary
- verify that each `fromValue` method returns the correct enum
- ensure invalid integers throw `ArgumentError`

## Testing
- `dart pub get` *(fails: Flutter SDK required)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487f24b1d0832db8b3d066d2ee478f