### PR TITLE
Add basic object API

### DIFF
--- a/lib/git2dart.dart
+++ b/lib/git2dart.dart
@@ -23,6 +23,7 @@ export 'src/odb.dart';
 export 'src/oid.dart';
 export 'src/packbuilder.dart';
 export 'src/patch.dart';
+export 'src/object.dart';
 export 'src/rebase.dart';
 export 'src/reference.dart';
 export 'src/reflog.dart';

--- a/lib/src/checkout.dart
+++ b/lib/src/checkout.dart
@@ -113,7 +113,7 @@ class Checkout {
     final treeish = object_bindings.lookup(
       repoPointer: repo.pointer,
       oidPointer: ref.target.pointer,
-      type: git_object_t.fromValue(GitObject.any.value),
+      type: git_object_t.fromValue(GitObjectType.any.value),
     );
 
     bindings.tree(
@@ -157,7 +157,7 @@ class Checkout {
     final treeish = object_bindings.lookup(
       repoPointer: repo.pointer,
       oidPointer: commit.oid.pointer,
-      type: git_object_t.fromValue(GitObject.any.value),
+      type: git_object_t.fromValue(GitObjectType.any.value),
     );
 
     bindings.tree(

--- a/lib/src/git_types.dart
+++ b/lib/src/git_types.dart
@@ -90,7 +90,7 @@ enum GitSort {
 }
 
 /// Basic type (loose or packed) of any Git object.
-enum GitObject {
+enum GitObjectType {
   /// Object can be any of the following.
   any(-2),
 
@@ -115,10 +115,10 @@ enum GitObject {
   /// A delta, base is given by object id.
   refDelta(7);
 
-  const GitObject(this.value);
+  const GitObjectType(this.value);
   final int value;
 
-  static GitObject fromValue(int value) => switch (value) {
+  static GitObjectType fromValue(int value) => switch (value) {
     -2 => any,
     -1 => invalid,
     1 => commit,
@@ -127,7 +127,7 @@ enum GitObject {
     4 => tag,
     6 => offsetDelta,
     7 => refDelta,
-    _ => throw ArgumentError('Unknown value for GitObject: $value'),
+    _ => throw ArgumentError('Unknown value for GitObjectType: $value'),
   };
 }
 

--- a/lib/src/libgit2.dart
+++ b/lib/src/libgit2.dart
@@ -138,7 +138,7 @@ class Libgit2 {
   /// Setting [value] to zero means objects of that type won't be cached.
   /// Defaults to 0 for blobs and 4k for commits, trees and tags.
   static void setCacheObjectLimit({
-    required GitObject type,
+    required GitObjectType type,
     required int value,
   }) {
     libgit2.git_libgit2_init();

--- a/lib/src/object.dart
+++ b/lib/src/object.dart
@@ -1,0 +1,89 @@
+import 'dart:ffi';
+
+import 'package:equatable/equatable.dart';
+import 'package:git2dart/git2dart.dart';
+import 'package:git2dart/src/bindings/object.dart' as bindings;
+import 'package:git2dart_binaries/git2dart_binaries.dart';
+import 'package:meta/meta.dart';
+
+/// A generic Git object wrapping [git_object] pointer.
+@immutable
+class GitObject extends Equatable {
+  /// Initializes [GitObject] from existing pointer.
+  @internal
+  GitObject._(this._objectPointer) {
+    _finalizer.attach(this, _objectPointer, detach: this);
+  }
+
+  /// Lookups object in [repo] for provided [oid].
+  ///
+  /// Throws a [LibGit2Error] if error occurred.
+  factory GitObject.lookup({
+    required Repository repo,
+    required Oid oid,
+    GitObjectType type = GitObjectType.any,
+  }) {
+    final pointer = bindings.lookup(
+      repoPointer: repo.pointer,
+      oidPointer: oid.pointer,
+      type: git_object_t.fromValue(type.value),
+    );
+    return GitObject._(pointer);
+  }
+
+  late final Pointer<git_object> _objectPointer;
+
+  /// Pointer to underlying git_object.
+  @internal
+  Pointer<git_object> get pointer => _objectPointer;
+
+  /// Type of this object.
+  GitObjectType get type {
+    final t = bindings.type(_objectPointer);
+    return GitObjectType.fromValue(t.value);
+  }
+
+  /// Object id.
+  Oid get oid => Oid.fromRaw(libgit2.git_object_id(_objectPointer).ref);
+
+  /// Get short abbreviated OID string.
+  String get shortId => bindings.shortId(objectPointer: _objectPointer);
+
+  /// Recursively peel object to [targetType].
+  GitObject peel({required GitObjectType targetType}) {
+    final pointer = bindings.peel(
+      objectPointer: _objectPointer,
+      targetType: git_object_t.fromValue(targetType.value),
+    );
+    return GitObject._(pointer);
+  }
+
+  /// Convert string to [GitObjectType].
+  static GitObjectType string2type(String type) {
+    final res = bindings.string2type(type);
+    return GitObjectType.fromValue(res.value);
+  }
+
+  /// Convert [type] to its string representation.
+  static String type2string(GitObjectType type) {
+    return bindings.type2string(git_object_t.fromValue(type.value));
+  }
+
+  /// Release allocated memory.
+  void free() {
+    bindings.free(_objectPointer);
+    _finalizer.detach(this);
+  }
+
+  @override
+  String toString() => 'GitObject{oid: \$oid, type: \$type}';
+
+  @override
+  List<Object?> get props => [oid];
+}
+
+// coverage:ignore-start
+final _finalizer = Finalizer<Pointer<git_object>>(
+  (pointer) => bindings.free(pointer),
+);
+// coverage:ignore-end

--- a/lib/src/odb.dart
+++ b/lib/src/odb.dart
@@ -78,16 +78,16 @@ class Odb extends Equatable {
 
   /// Writes raw [data] into the object database.
   ///
-  /// [type] should be one of [GitObject.blob], [GitObject.commit],
-  /// [GitObject.tag] or [GitObject.tree].
+  /// [type] should be one of [GitObjectType.blob], [GitObjectType.commit],
+  /// [GitObjectType.tag] or [GitObjectType.tree].
   ///
   /// Throws a [LibGit2Error] if error occurred or [ArgumentError] if provided
   /// type is invalid.
-  Oid write({required GitObject type, required String data}) {
-    if (type == GitObject.any ||
-        type == GitObject.invalid ||
-        type == GitObject.offsetDelta ||
-        type == GitObject.refDelta) {
+  Oid write({required GitObjectType type, required String data}) {
+    if (type == GitObjectType.any ||
+        type == GitObjectType.invalid ||
+        type == GitObjectType.offsetDelta ||
+        type == GitObjectType.refDelta) {
       throw ArgumentError.value('$type is invalid type');
     } else {
       return Oid(
@@ -134,9 +134,9 @@ class OdbObject extends Equatable {
   Oid get oid => Oid(bindings.objectId(_odbObjectPointer));
 
   /// Type of an ODB object.
-  GitObject get type {
+  GitObjectType get type {
     final typeInt = bindings.objectType(_odbObjectPointer);
-    return GitObject.fromValue(typeInt.value);
+    return GitObjectType.fromValue(typeInt.value);
   }
 
   /// Uncompressed, raw data as read from the ODB, without the leading header.

--- a/lib/src/reference.dart
+++ b/lib/src/reference.dart
@@ -233,27 +233,27 @@ class Reference extends Equatable {
   /// object types.
   ///
   /// ```dart
-  /// final commit = ref.peel(GitObject.commit) as Commit;
-  /// final tree = ref.peel(GitObject.tree) as Tree;
-  /// final blob = ref.peel(GitObject.blob) as Blob;
-  /// final tag = ref.peel(GitObject.tag) as Tag;
+  /// final commit = ref.peel(GitObjectType.commit) as Commit;
+  /// final tree = ref.peel(GitObjectType.tree) as Tree;
+  /// final blob = ref.peel(GitObjectType.blob) as Blob;
+  /// final tag = ref.peel(GitObjectType.tag) as Tag;
   /// ```
   ///
   /// Throws a [LibGit2Error] if error occured.
-  Object peel([GitObject type = GitObject.any]) {
+  Object peel([GitObjectType type = GitObjectType.any]) {
     final object = bindings.peel(
       refPointer: _refPointer,
       type: git_object_t.fromValue(type.value),
     );
     final objectType = object_bindings.type(object);
 
-    if (objectType.value == GitObject.commit.value) {
+    if (objectType.value == GitObjectType.commit.value) {
       return Commit(object.cast());
-    } else if (objectType.value == GitObject.tree.value) {
+    } else if (objectType.value == GitObjectType.tree.value) {
       return Tree(object.cast());
-    } else if (objectType.value == GitObject.blob.value) {
+    } else if (objectType.value == GitObjectType.blob.value) {
       return Blob(object.cast());
-    } else if (objectType.value == GitObject.tag.value) {
+    } else if (objectType.value == GitObjectType.tag.value) {
       return Tag(object.cast());
     } else {
       throw ArgumentError.value('Invalid object type: $objectType');

--- a/lib/src/repository.dart
+++ b/lib/src/repository.dart
@@ -564,7 +564,7 @@ class Repository extends Equatable {
     final object = object_bindings.lookup(
       repoPointer: _repoPointer,
       oidPointer: oid.pointer,
-      type: git_object_t.fromValue(GitObject.any.value),
+      type: git_object_t.fromValue(GitObjectType.any.value),
     );
 
     reset_bindings.reset(
@@ -594,7 +594,7 @@ class Repository extends Equatable {
       object = object_bindings.lookup(
         repoPointer: _repoPointer,
         oidPointer: oid.pointer,
-        type: git_object_t.fromValue(GitObject.commit.value),
+        type: git_object_t.fromValue(GitObjectType.commit.value),
       );
     }
 

--- a/lib/src/tag.dart
+++ b/lib/src/tag.dart
@@ -61,9 +61,9 @@ class Tag extends Equatable {
   Signature get tagger => Signature(bindings.tagger(_tagPointer));
 
   /// Gets the type of the tagged object.
-  GitObject get targetType {
+  GitObjectType get targetType {
     final type = bindings.targetType(_tagPointer);
-    return GitObject.fromValue(type.value);
+    return GitObjectType.fromValue(type.value);
   }
 
   /// Gets the [Oid] of the tagged object.
@@ -71,20 +71,20 @@ class Tag extends Equatable {
 
   /// Gets the tagged object.
   ///
-  /// Returns a [GitObject] representing the tagged object.
+  /// Returns a [GitObjectType] representing the tagged object.
   ///
   /// Throws a [LibGit2Error] if an error occurs.
   Object get target {
     final type = bindings.targetType(_tagPointer);
     final object = bindings.target(_tagPointer);
 
-    if (type.value == GitObject.commit.value) {
+    if (type.value == GitObjectType.commit.value) {
       return Commit(object.cast());
-    } else if (type.value == GitObject.tree.value) {
+    } else if (type.value == GitObjectType.tree.value) {
       return Tree(object.cast());
-    } else if (type.value == GitObject.blob.value) {
+    } else if (type.value == GitObjectType.blob.value) {
       return Blob(object.cast());
-    } else if (type.value == GitObject.tag.value) {
+    } else if (type.value == GitObjectType.tag.value) {
       return Tag(object.cast());
     } else {
       throw ArgumentError('Unsupported tag target type: ${type.value}');
@@ -108,7 +108,7 @@ class Tag extends Equatable {
     required Repository repo,
     required String tagName,
     required Oid target,
-    required GitObject targetType,
+    required GitObjectType targetType,
     required Signature tagger,
     required String message,
     bool force = false,
@@ -149,13 +149,13 @@ class Tag extends Equatable {
     required Repository repo,
     required String tagName,
     required Oid target,
-    required GitObject targetType,
+    required GitObjectType targetType,
     bool force = false,
   }) {
     final object = object_bindings.lookup(
       repoPointer: repo.pointer,
       oidPointer: target.pointer,
-      type: git_object_t.fromValue(GitObject.any.value),
+      type: git_object_t.fromValue(GitObjectType.any.value),
     );
 
     final result = bindings.createLightweight(

--- a/test/describe_test.dart
+++ b/test/describe_test.dart
@@ -81,7 +81,7 @@ void main() {
         repo: repo,
         tagName: 'test/tag1',
         target: repo['f17d0d4'],
-        targetType: GitObject.commit,
+        targetType: GitObjectType.commit,
         tagger: signature,
         message: 'message',
       );

--- a/test/git_types_test.dart
+++ b/test/git_types_test.dart
@@ -39,18 +39,18 @@ void main() {
       expect(actual, expected);
     });
 
-    test('GitObject returns correct values', () {
+    test('GitObjectType returns correct values', () {
       const expected = {
-        GitObject.any: -2,
-        GitObject.invalid: -1,
-        GitObject.commit: 1,
-        GitObject.tree: 2,
-        GitObject.blob: 3,
-        GitObject.tag: 4,
-        GitObject.offsetDelta: 6,
-        GitObject.refDelta: 7,
+        GitObjectType.any: -2,
+        GitObjectType.invalid: -1,
+        GitObjectType.commit: 1,
+        GitObjectType.tree: 2,
+        GitObjectType.blob: 3,
+        GitObjectType.tag: 4,
+        GitObjectType.offsetDelta: 6,
+        GitObjectType.refDelta: 7,
       };
-      final actual = {for (final e in GitObject.values) e: e.value};
+      final actual = {for (final e in GitObjectType.values) e: e.value};
       expect(actual, expected);
     });
 

--- a/test/libgit2_test.dart
+++ b/test/libgit2_test.dart
@@ -70,12 +70,12 @@ void main() {
     test('sets the maximum data size for the given type of object '
         'to be considered eligible for caching in memory', () {
       expect(
-        () => Libgit2.setCacheObjectLimit(type: GitObject.blob, value: 420),
+        () => Libgit2.setCacheObjectLimit(type: GitObjectType.blob, value: 420),
         returnsNormally,
       );
 
       // Reset to avoid side effects in later tests
-      Libgit2.setCacheObjectLimit(type: GitObject.blob, value: 0);
+      Libgit2.setCacheObjectLimit(type: GitObjectType.blob, value: 0);
     });
 
     test('sets the maximum cache size', () {

--- a/test/object_binding_test.dart
+++ b/test/object_binding_test.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+import 'dart:ffi';
+
+import 'package:git2dart/git2dart.dart';
+import 'package:git2dart/src/bindings/object.dart' as bindings;
+import 'package:git2dart/src/libgit2.dart' as libgit2;
+import 'package:git2dart_binaries/git2dart_binaries.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'helpers/util.dart';
+
+void main() {
+  late Repository repo;
+  late Directory tmpDir;
+  const commitSha = '78b8bf123e3952c970ae5c1ce0a3ea1d1336f6e8';
+  const tagSha = 'f0fdbf506397e9f58c59b88dfdd72778ec06cc0c';
+  const peeledCommitSha = '821ed6e80627b8769d170a293862f9fc60825226';
+
+  setUp(() {
+    tmpDir = setupRepo(Directory(p.join('test', 'assets', 'test_repo')));
+    repo = Repository.open(tmpDir.path);
+  });
+
+  tearDown(() {
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  group('object bindings', () {
+    test('lookup, peel, type, shortId and free', () {
+      final commitObj = bindings.lookup(
+        repoPointer: repo.pointer,
+        oidPointer: repo[commitSha].pointer,
+        type: git_object_t.GIT_OBJECT_ANY,
+      );
+
+      expect(
+        Oid.fromRaw(libgit2.libgit2.git_object_id(commitObj).ref).sha,
+        commitSha,
+      );
+      expect(bindings.type(commitObj), git_object_t.GIT_OBJECT_COMMIT);
+      expect(bindings.shortId(objectPointer: commitObj), '78b8bf1');
+
+      final tagObj = bindings.lookup(
+        repoPointer: repo.pointer,
+        oidPointer: repo[tagSha].pointer,
+        type: git_object_t.GIT_OBJECT_TAG,
+      );
+      final peeled = bindings.peel(
+        objectPointer: tagObj,
+        targetType: git_object_t.GIT_OBJECT_COMMIT,
+      );
+      expect(
+        Oid.fromRaw(libgit2.libgit2.git_object_id(peeled).ref).sha,
+        peeledCommitSha,
+      );
+
+      bindings.free(commitObj);
+      bindings.free(tagObj);
+      bindings.free(peeled);
+    });
+
+    test('string2type and type2string', () {
+      final t = bindings.string2type('commit');
+      expect(t, git_object_t.GIT_OBJECT_COMMIT);
+      expect(bindings.type2string(t), 'commit');
+    });
+  });
+}

--- a/test/object_test.dart
+++ b/test/object_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:git2dart/git2dart.dart';
+import 'package:git2dart_binaries/git2dart_binaries.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'helpers/util.dart';
+
+void main() {
+  late Repository repo;
+  late Directory tmpDir;
+  const commitSha = '78b8bf123e3952c970ae5c1ce0a3ea1d1336f6e8';
+  const tagSha = 'f0fdbf506397e9f58c59b88dfdd72778ec06cc0c';
+  const peeledCommitSha = '821ed6e80627b8769d170a293862f9fc60825226';
+
+  setUp(() {
+    tmpDir = setupRepo(Directory(p.join('test', 'assets', 'test_repo')));
+    repo = Repository.open(tmpDir.path);
+  });
+
+  tearDown(() {
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  group('GitObject', () {
+    test('lookup, type and shortId', () {
+      final object = GitObject.lookup(
+        repo: repo,
+        oid: repo[commitSha],
+      );
+
+      expect(object.oid.sha, commitSha);
+      expect(object.type, GitObjectType.commit);
+      expect(object.shortId, '78b8bf1');
+      object.free();
+    });
+
+    test('peel object to commit', () {
+      final tagObject = GitObject.lookup(
+        repo: repo,
+        oid: repo[tagSha],
+        type: GitObjectType.tag,
+      );
+
+      final peeled = tagObject.peel(targetType: GitObjectType.commit);
+
+      expect(peeled.oid.sha, peeledCommitSha);
+
+      peeled.free();
+      tagObject.free();
+    });
+
+    test('string2type and type2string', () {
+      final type = GitObject.string2type('commit');
+      expect(type, GitObjectType.commit);
+      expect(GitObject.type2string(type), 'commit');
+    });
+  });
+}

--- a/test/odb_test.dart
+++ b/test/odb_test.dart
@@ -48,7 +48,7 @@ void main() {
       final object = repo.odb.read(repo[blobSha]);
 
       expect(object.oid, repo[blobSha]);
-      expect(object.type, GitObject.blob);
+      expect(object.type, GitObjectType.blob);
       expect(object.data, blobContent);
       expect(object.size, 13);
       expect(object, equals(repo.odb.read(repo[blobSha])));
@@ -74,7 +74,7 @@ void main() {
 
     test('writes data', () {
       final odb = repo.odb;
-      final oid = odb.write(type: GitObject.blob, data: 'testing');
+      final oid = odb.write(type: GitObjectType.blob, data: 'testing');
       final object = odb.read(oid);
 
       expect(odb.contains(oid), true);
@@ -83,7 +83,7 @@ void main() {
 
     test('throws when trying to write with invalid object type', () {
       expect(
-        () => repo.odb.write(type: GitObject.any, data: 'testing'),
+        () => repo.odb.write(type: GitObjectType.any, data: 'testing'),
         throwsA(isA<ArgumentError>()),
       );
     });
@@ -93,7 +93,7 @@ void main() {
       odb.addDiskAlternate(p.join(repo.path, 'objects'));
 
       expect(
-        () => odb.write(type: GitObject.blob, data: ''),
+        () => odb.write(type: GitObjectType.blob, data: ''),
         throwsA(isA<LibGit2Error>()),
       );
     });

--- a/test/reference_test.dart
+++ b/test/reference_test.dart
@@ -468,7 +468,7 @@ void main() {
     test('peels to non-tag object when no type is provided', () {
       final ref = Reference.lookup(repo: repo, name: 'refs/heads/master');
       final commit = Commit.lookup(repo: repo, oid: ref.target);
-      final peeled = ref.peel(GitObject.commit) as Commit;
+      final peeled = ref.peel(GitObjectType.commit) as Commit;
 
       expect(peeled.oid, commit.oid);
     });
@@ -483,10 +483,10 @@ void main() {
       final tagRef = Reference.lookup(repo: repo, name: 'refs/tags/v0.2');
       final commit = Commit.lookup(repo: repo, oid: ref.target);
 
-      final peeledCommit = ref.peel(GitObject.commit) as Commit;
-      final peeledTree = ref.peel(GitObject.tree) as Tree;
-      final peeledBlob = blobRef.peel(GitObject.blob) as Blob;
-      final peeledTag = tagRef.peel(GitObject.tag) as Tag;
+      final peeledCommit = ref.peel(GitObjectType.commit) as Commit;
+      final peeledTree = ref.peel(GitObjectType.tree) as Tree;
+      final peeledBlob = blobRef.peel(GitObjectType.blob) as Blob;
+      final peeledTag = tagRef.peel(GitObjectType.tag) as Tag;
 
       expect(peeledCommit.oid, commit.oid);
       expect(peeledTree.oid, commit.tree.oid);

--- a/test/tag_test.dart
+++ b/test/tag_test.dart
@@ -49,7 +49,7 @@ void main() {
       expect(tag.oid, tagOid);
       expect(tag.name, 'v0.2');
       expect(tag.message, 'annotated tag\n');
-      expect(tag.targetType, GitObject.commit);
+      expect(tag.targetType, GitObjectType.commit);
       expect(target.message, 'add subdirectory file\n');
       expect(tag.tagger, signature);
       expect(tag.toString(), contains('Tag{'));
@@ -70,7 +70,7 @@ void main() {
         repo: repo,
         tagName: tagName,
         target: target,
-        targetType: GitObject.commit,
+        targetType: GitObjectType.commit,
         tagger: signature,
         message: message,
       );
@@ -94,7 +94,7 @@ void main() {
         repo: repo,
         tagName: tagName,
         target: target,
-        targetType: GitObject.commit,
+        targetType: GitObjectType.commit,
       );
 
       final newTag = Reference.lookup(repo: repo, name: 'refs/tags/$tagName');
@@ -117,7 +117,7 @@ void main() {
         repo: repo,
         tagName: tagName,
         target: target,
-        targetType: GitObject.tree,
+        targetType: GitObjectType.tree,
         tagger: signature,
         message: message,
       );
@@ -140,7 +140,7 @@ void main() {
         repo: repo,
         tagName: tagName,
         target: target,
-        targetType: GitObject.tree,
+        targetType: GitObjectType.tree,
       );
 
       final newTag = Reference.lookup(repo: repo, name: 'refs/tags/$tagName');
@@ -163,7 +163,7 @@ void main() {
         repo: repo,
         tagName: tagName,
         target: target,
-        targetType: GitObject.blob,
+        targetType: GitObjectType.blob,
         tagger: signature,
         message: message,
       );
@@ -186,7 +186,7 @@ void main() {
         repo: repo,
         tagName: tagName,
         target: target,
-        targetType: GitObject.blob,
+        targetType: GitObjectType.blob,
       );
 
       final newTag = Reference.lookup(repo: repo, name: 'refs/tags/$tagName');
@@ -208,7 +208,7 @@ void main() {
         repo: repo,
         tagName: tagName,
         target: tag.oid,
-        targetType: GitObject.tag,
+        targetType: GitObjectType.tag,
         tagger: signature,
         message: message,
       );
@@ -230,7 +230,7 @@ void main() {
         repo: repo,
         tagName: tagName,
         target: tag.oid,
-        targetType: GitObject.tag,
+        targetType: GitObjectType.tag,
       );
 
       final newTag = Reference.lookup(repo: repo, name: 'refs/tags/$tagName');
@@ -258,7 +258,7 @@ void main() {
         repo: repo,
         tagName: tagName,
         target: target,
-        targetType: GitObject.commit,
+        targetType: GitObjectType.commit,
         tagger: signature,
         message: message,
         force: true,
@@ -289,7 +289,7 @@ void main() {
         repo: repo,
         tagName: tagName,
         target: target,
-        targetType: GitObject.commit,
+        targetType: GitObjectType.commit,
         force: true,
       );
 
@@ -306,7 +306,7 @@ void main() {
           repo: repo,
           tagName: '',
           target: repo['9c78c21'],
-          targetType: GitObject.any,
+          targetType: GitObjectType.any,
           tagger: Signature(nullptr),
           message: '',
         ),
@@ -320,7 +320,7 @@ void main() {
           repo: repo,
           tagName: '',
           target: repo['9c78c21'],
-          targetType: GitObject.any,
+          targetType: GitObjectType.any,
         ),
         throwsA(isA<LibGit2Error>()),
       );
@@ -332,7 +332,7 @@ void main() {
           repo: repo,
           tagName: '',
           target: repo['0' * 40],
-          targetType: GitObject.commit,
+          targetType: GitObjectType.commit,
           tagger: Signature(nullptr),
           message: '',
         ),
@@ -348,7 +348,7 @@ void main() {
             repo: repo,
             tagName: '',
             target: repo['0' * 40],
-            targetType: GitObject.commit,
+            targetType: GitObjectType.commit,
           ),
           throwsA(isA<LibGit2Error>()),
         );


### PR DESCRIPTION
## Summary
- introduce `GitObject` wrapper exposing lookup/peel helpers
- rename `GitObject` enum to `GitObjectType`
- update exports and adapt code/tests to new enum
- add tests for generic object operations
- add low-level bindings test for object helper functions

## Testing
- ❌ `dart test -r expanded` *(failed: git2dart requires the Flutter SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68487f146f34832d94877e118436ce6b